### PR TITLE
Tested having the ability to have the camera use either Update or Fix…

### DIFF
--- a/Assets/Scenes/Testing-Enviroment.unity
+++ b/Assets/Scenes/Testing-Enviroment.unity
@@ -1231,7 +1231,7 @@ MonoBehaviour:
     m_Bits: 1
   lookMode: 1
   invertCamera: 1
-  camAxisRotDamping_C: 1
+  camAxisRotDamping_C: 150
   camAxisVerticalAngle: 0
   camAxisAngleClampTolerance: 10
   camAxisLowerAngleClamp: 80

--- a/Assets/Scripts/CameraController.cs
+++ b/Assets/Scripts/CameraController.cs
@@ -106,7 +106,6 @@ namespace SolidSky
                 camAxisUpperAngleClamp = 70f + camAxisAngleClampTolerance;
             }
 
-            
             camAxisUpperAngleClamp = Mathf.Clamp(camAxisUpperAngleClamp, -70f, 80f);
         }
         private void Awake()
@@ -227,7 +226,7 @@ namespace SolidSky
 
                 if (inputManager.cameraX != 0f || inputManager.cameraY != 0f)
                 {
-                    camOrbitAxis.Rotate(GetCamOrbitAxisTargetRot(inputManager.cameraX, -inputManager.cameraY, camAxisRotDamping_C, invertCamera, false));
+                    camOrbitAxis.Rotate(GetCamOrbitAxisTargetRot(inputManager.cameraX, -inputManager.cameraY, camAxisRotDamping_C, invertCamera, true));
                     camOrbitAxis.eulerAngles = new Vector3(camOrbitAxis.eulerAngles.x, camOrbitAxis.eulerAngles.y, 0f);
                 }
             }
@@ -257,6 +256,7 @@ namespace SolidSky
             {
                 transform.rotation = Quaternion.Slerp(transform.rotation, camTargetRotation, camRotDamping * Time.deltaTime);
             }
+            
         }
 
         private Vector3 GetCamOrbitAxisTargetRot(float horz, float vert, float damp, bool inverted, bool useDeltaTime)


### PR DESCRIPTION
…edUpdate however due to its heavy reliance on raycasting, the current way things are structured, the camera functions must remain in FixedUpdate and use Time.deltaTime to keep camera movement fluid. Re-added all uses of Time.deltaTime that were removed on the previous version